### PR TITLE
fix: add missing import for Unix permissions in config.rs

### DIFF
--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -6,6 +6,8 @@ use std::env;
 use std::fs::{self, File};
 use log::{debug, error};
 use crate::domain::errors::config_error::ConfigError;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 #[derive(Debug, Clone)]
 pub struct Config {


### PR DESCRIPTION
closes #561